### PR TITLE
Support for finding app by bundle id

### DIFF
--- a/Source/HedgeModManager/ObjectiveC/NSString.cs
+++ b/Source/HedgeModManager/ObjectiveC/NSString.cs
@@ -1,0 +1,19 @@
+using System.Runtime.Versioning;
+
+namespace HedgeModManager.ObjectiveC
+{
+    [SupportedOSPlatform("macos")]
+    public struct NSString : IDisposable
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(NSString obj) => obj.NativePtr;
+        public NSString(IntPtr ptr) => NativePtr = ptr;
+
+        public void Dispose()
+        {
+            ObjectiveC.objc_msgSend(NativePtr, sel_release);
+        }
+
+        private static readonly Selector sel_release = "release";
+    }
+}

--- a/Source/HedgeModManager/ObjectiveC/NSWorkspace.cs
+++ b/Source/HedgeModManager/ObjectiveC/NSWorkspace.cs
@@ -1,0 +1,29 @@
+using System.Runtime.Versioning;
+
+namespace HedgeModManager.ObjectiveC
+{
+    [SupportedOSPlatform("macos")]
+    public struct NSWorkspace
+    {
+        public IntPtr NativePtr;
+        public static implicit operator IntPtr(NSWorkspace obj) => obj.NativePtr;
+
+        public NSWorkspace()
+        {
+            // Ensure AppKit is linked
+            ObjectiveC.LinkAppKit();
+
+            var cls = new ObjectiveCClass("NSWorkspace");
+            NativePtr = ObjectiveC.IntPtr_objc_msgSend(cls, new Selector("sharedWorkspace"));
+        }
+
+        public string UrlForApplicationWithBundleIdentifier(string bundleIdentifier)
+        {
+            var nsString = StringHelper.NSString(bundleIdentifier);
+            var path = ObjectiveC.IntPtr_objc_msgSend(NativePtr, new Selector("URLForApplicationWithBundleIdentifier:"), nsString);
+            nsString.Dispose();
+
+            return new string(ObjectiveC.string_objc_msgSend(path, new Selector("fileSystemRepresentation")));
+        }
+    }
+}

--- a/Source/HedgeModManager/ObjectiveC/ObjectiveC.cs
+++ b/Source/HedgeModManager/ObjectiveC/ObjectiveC.cs
@@ -1,0 +1,40 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace HedgeModManager.ObjectiveC
+{
+    [SupportedOSPlatform("macos")]
+    public static partial class ObjectiveC
+    {
+        public const string ObjCRuntime = "/usr/lib/libobjc.A.dylib";
+        public const string Libdl = "libdl.dylib";
+
+        public const string AppKitFramework = "/System/Library/Frameworks/AppKit.framework/AppKit";
+
+        [LibraryImport(ObjCRuntime, StringMarshalling = StringMarshalling.Utf8)]
+        public static partial IntPtr objc_getClass(string name);
+
+        [LibraryImport(Libdl, StringMarshalling = StringMarshalling.Utf8)]
+        private static partial IntPtr dlopen(string path, int mode);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial void objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, Selector selector);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, Selector selector, string param);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend")]
+        public static partial IntPtr IntPtr_objc_msgSend(IntPtr receiver, Selector selector, IntPtr a);
+
+        [LibraryImport(ObjCRuntime, EntryPoint = "objc_msgSend", StringMarshalling = StringMarshalling.Utf8)]
+        public static partial string string_objc_msgSend(IntPtr receiver, Selector selector);
+
+        public static IntPtr LinkAppKit()
+        {
+            return dlopen(AppKitFramework, 0);
+        }
+    }
+}

--- a/Source/HedgeModManager/ObjectiveC/ObjectiveCClass.cs
+++ b/Source/HedgeModManager/ObjectiveC/ObjectiveCClass.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Versioning;
+
+namespace HedgeModManager.ObjectiveC
+{
+    [SupportedOSPlatform("macos")]
+    public readonly struct ObjectiveCClass
+    {
+        public readonly IntPtr NativePtr;
+        public static implicit operator IntPtr(ObjectiveCClass c) => c.NativePtr;
+
+        public ObjectiveCClass(string name)
+        {
+            var ptr = ObjectiveC.objc_getClass(name);
+
+            if (ptr == IntPtr.Zero)
+            {
+                Console.WriteLine($"Failed to get class {name}!");
+            }
+
+            NativePtr = ptr;
+        }
+    }
+}

--- a/Source/HedgeModManager/ObjectiveC/Selector.cs
+++ b/Source/HedgeModManager/ObjectiveC/Selector.cs
@@ -1,0 +1,29 @@
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace HedgeModManager.ObjectiveC
+{
+    [SupportedOSPlatform("macos")]
+    public readonly partial struct Selector
+    {
+        [LibraryImport("/usr/lib/libobjc.A.dylib", StringMarshalling = StringMarshalling.Utf8)]
+        private static unsafe partial IntPtr sel_getUid(string name);
+
+        public readonly IntPtr SelPtr;
+
+        public Selector(string name)
+        {
+            var ptr = sel_getUid(name);
+
+            if (ptr == IntPtr.Zero)
+            {
+                Console.WriteLine($"Failed to get selector {name}!");
+            }
+
+            SelPtr = ptr;
+        }
+
+        public static implicit operator Selector(string value) => new(value);
+        public static implicit operator IntPtr(Selector sel) => sel.SelPtr;
+    }
+}

--- a/Source/HedgeModManager/ObjectiveC/Selector.cs
+++ b/Source/HedgeModManager/ObjectiveC/Selector.cs
@@ -6,7 +6,7 @@ namespace HedgeModManager.ObjectiveC
     [SupportedOSPlatform("macos")]
     public readonly partial struct Selector
     {
-        [LibraryImport("/usr/lib/libobjc.A.dylib", StringMarshalling = StringMarshalling.Utf8)]
+        [LibraryImport(ObjectiveC.ObjCRuntime, StringMarshalling = StringMarshalling.Utf8)]
         private static unsafe partial IntPtr sel_getUid(string name);
 
         public readonly IntPtr SelPtr;

--- a/Source/HedgeModManager/ObjectiveC/StringHelper.cs
+++ b/Source/HedgeModManager/ObjectiveC/StringHelper.cs
@@ -1,0 +1,13 @@
+using System.Runtime.Versioning;
+
+namespace HedgeModManager.ObjectiveC
+{
+    [SupportedOSPlatform("macos")]
+    public static class StringHelper
+    {
+        public static NSString NSString(string source)
+        {
+            return new(ObjectiveC.IntPtr_objc_msgSend(new ObjectiveCClass("NSString"), "stringWithUTF8String:", source));
+        }
+    }
+}


### PR DESCRIPTION
This allows for finding recomp using

`new NSWorkspace().UrlForApplicationWithBundleIdentifier("hedge-dev.UnleashedRecomp");`